### PR TITLE
Add requirements file and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ User provides a playlist link (e.g., from Spotify):
   * Generate `.zip`
   * Serve zip and delete all files
 
+## ⚙️ Setup
+
+1. Clone the repository.
+2. Install Python 3.10+.
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Run the FastAPI server (example):
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
 ### Frontend (optional)
 
 * Next.js + Tailwind CSS (planned UI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+yt-dlp
+spotdl
+scdl
+pytest


### PR DESCRIPTION
## Summary
- add `requirements.txt` with backend and test dependencies
- document setup steps referencing the new requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498b159f24832894917a83946155ea