### PR TITLE
Add youtube, spotify and soundcloud download helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ allplatformmusic/
 └── README.md
 ```
 
+### Downloader Modules
+
+The downloader package exposes convenience functions:
+
+* `download_youtube_track(url: str, output_dir: Path) -> Path`
+* `fetch_spotify_playlist(playlist_url: str) -> List[str]`
+* `download_soundcloud_track(url: str, output_dir: Path) -> Path`
+
+These helpers are thin wrappers around ``yt-dlp``, ``spotdl`` and ``scdl``
+respectively.
+
 ---
 
 ## 👋 Contributing

--- a/backend/downloader/soundcloud.py
+++ b/backend/downloader/soundcloud.py
@@ -1,5 +1,43 @@
-class SoundCloudDownloader:
-    """Placeholder for SoundCloud download logic."""
+"""SoundCloud download utilities using ``scdl``."""
 
-    def download(self, url: str) -> None:
-        pass
+import subprocess
+from pathlib import Path
+
+
+def download_soundcloud_track(url: str, output_dir: Path) -> Path:
+    """Download a track from SoundCloud via ``scdl`` command.
+
+    Parameters
+    ----------
+    url:
+        SoundCloud track link.
+    output_dir:
+        Destination directory for the download.
+
+    Returns
+    -------
+    Path
+        Path of the downloaded file.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "scdl",
+        "--onlymp3",
+        "--path",
+        str(output_dir),
+        "-l",
+        url,
+    ]
+    subprocess.run(cmd, check=True)
+    latest = max(output_dir.glob("*"), key=lambda p: p.stat().st_mtime)
+    return latest
+
+
+class SoundCloudDownloader:
+    """Wrapper class exposing ``download`` for single tracks."""
+
+    def download(self, url: str, output_dir: Path) -> Path:
+        """Download ``url`` using :func:`download_soundcloud_track`."""
+
+        return download_soundcloud_track(url, output_dir)

--- a/backend/downloader/spotify.py
+++ b/backend/downloader/spotify.py
@@ -1,5 +1,32 @@
-class SpotifyDownloader:
-    """Placeholder for Spotify download logic."""
+"""Helpers for interacting with Spotify playlists via ``spotdl``."""
 
-    def download(self, url: str) -> None:
-        pass
+from typing import List
+from spotdl import Spotdl
+
+
+def fetch_spotify_playlist(playlist_url: str) -> List[str]:
+    """Return a list of track titles contained in ``playlist_url``.
+
+    Parameters
+    ----------
+    playlist_url:
+        Link to the Spotify playlist.
+
+    Returns
+    -------
+    List[str]
+        The track names found in the playlist.
+    """
+
+    spotdl_handler = Spotdl()
+    songs = spotdl_handler.search([playlist_url])
+    return [song.title for song in songs]
+
+
+class SpotifyDownloader:
+    """Wrapper around :func:`fetch_spotify_playlist`."""
+
+    def download(self, url: str) -> List[str]:
+        """Fetch tracks from ``url`` using spotdl."""
+
+        return fetch_spotify_playlist(url)

--- a/backend/downloader/youtube.py
+++ b/backend/downloader/youtube.py
@@ -1,5 +1,43 @@
-class YouTubeDownloader:
-    """Placeholder for YouTube download logic."""
+"""YouTube download utilities using ``yt-dlp``."""
 
-    def download(self, url: str) -> None:
-        pass
+from pathlib import Path
+from yt_dlp import YoutubeDL
+
+
+def download_youtube_track(url: str, output_dir: Path) -> Path:
+    """Download a single track from YouTube.
+
+    Parameters
+    ----------
+    url:
+        The YouTube video URL.
+    output_dir:
+        Directory where the audio file will be placed.
+
+    Returns
+    -------
+    Path
+        Path to the downloaded audio file.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(output_dir / "%(title)s.%(ext)s"),
+        "quiet": True,
+    }
+
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        filename = ydl.prepare_filename(info)
+
+    return Path(filename)
+
+
+class YouTubeDownloader:
+    """Simple wrapper class for YouTube downloads."""
+
+    def download(self, url: str, output_dir: Path) -> Path:
+        """Download ``url`` to ``output_dir`` using :func:`download_youtube_track`."""
+
+        return download_youtube_track(url, output_dir)


### PR DESCRIPTION
## Summary
- add download_youtube_track using yt-dlp
- use spotdl to fetch playlist tracks
- implement soundcloud downloads with scdl
- document downloader helper APIs in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498be7de5883288b0ee52fec9c3666