### PR TITLE
Implement matcher scoring and temp directory zipping

### DIFF
--- a/backend/utils/matcher.py
+++ b/backend/utils/matcher.py
@@ -1,6 +1,47 @@
-from typing import List
+from typing import Dict, List, Tuple
+from difflib import SequenceMatcher
 
 
 def find_best_match(query: str, candidates: List[str]) -> str:
     """Return the best matching candidate for the query."""
     return candidates[0] if candidates else ""
+
+
+def _similarity(a: str, b: str) -> float:
+    """Return a simple similarity ratio between two strings."""
+
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+
+def choose_best_match_across_platforms(
+    query: str, platform_results: Dict[str, List[str]]
+) -> Tuple[str, str]:
+    """Return the platform and candidate with the highest similarity score.
+
+    Parameters
+    ----------
+    query:
+        The search string used to find candidates.
+    platform_results:
+        Mapping of platform name to a list of candidate titles.
+
+    Returns
+    -------
+    Tuple[str, str]
+        ``(platform, title)`` pair of the best match. Empty strings if no
+        candidates were provided.
+    """
+
+    best_platform = ""
+    best_title = ""
+    best_score = 0.0
+
+    for platform, titles in platform_results.items():
+        for title in titles:
+            score = _similarity(query, title)
+            if score > best_score:
+                best_score = score
+                best_platform = platform
+                best_title = title
+
+    return best_platform, best_title

--- a/backend/utils/zipper.py
+++ b/backend/utils/zipper.py
@@ -7,3 +7,11 @@ def create_zip(source_dir: Path, zip_path: Path) -> None:
     with zipfile.ZipFile(zip_path, 'w') as zf:
         for file_path in source_dir.iterdir():
             zf.write(file_path, arcname=file_path.name)
+
+
+def zip_temp_directory(temp_dir: Path) -> Path:
+    """Zip ``temp_dir`` and return the path to the created archive."""
+
+    zip_path = temp_dir.with_suffix('.zip')
+    create_zip(temp_dir, zip_path)
+    return zip_path


### PR DESCRIPTION
## Summary
- enhance matcher module with similarity scoring across platforms
- add helper to create zip archive from a temporary directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498d881b6883289dc55c190d1ce659