### PR TITLE
Implement failure logging and cleanup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,34 @@
 """FastAPI server exposing music download endpoints."""
 
 import asyncio
+import shutil
 import tempfile
 from pathlib import Path
 
-from fastapi import FastAPI, File, UploadFile, Form, HTTPException
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException, BackgroundTasks
 from fastapi.responses import FileResponse
 
 from .downloader.youtube import download_youtube_track
 from .downloader.spotify import fetch_spotify_playlist
 from .utils.zipper import zip_temp_directory
 
+FAIL_LOG = Path("not_downloaded.txt")
+
 app = FastAPI()
+
+
+def _record_failure(track: str) -> None:
+    """Append ``track`` to the failure log."""
+    with FAIL_LOG.open("a") as f:
+        f.write(track + "\n")
+
+
+def _cleanup(zip_path: Path, temp_dir: Path) -> None:
+    """Delete created files and directories."""
+    if zip_path.exists():
+        zip_path.unlink()
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 async def _download_tracks(tracks: list[str], temp_dir: Path) -> None:
@@ -19,14 +36,19 @@ async def _download_tracks(tracks: list[str], temp_dir: Path) -> None:
 
     async def _download(track: str) -> None:
         query = f"ytsearch1:{track}"
-        await asyncio.to_thread(download_youtube_track, query, temp_dir)
+        try:
+            await asyncio.to_thread(download_youtube_track, query, temp_dir)
+        except Exception:
+            await asyncio.to_thread(_record_failure, track)
 
     tasks = [asyncio.create_task(_download(t)) for t in tracks]
     await asyncio.gather(*tasks)
 
 
 @app.post("/download/text")
-async def download_from_text(file: UploadFile = File(...)):
+async def download_from_text(
+    file: UploadFile = File(...), background_tasks: BackgroundTasks | None = None
+):
     """Accept a .txt file of tracks, download them and return a zip."""
 
     if not file.filename.endswith(".txt"):
@@ -42,11 +64,16 @@ async def download_from_text(file: UploadFile = File(...)):
     await _download_tracks(lines, temp_dir)
     zip_path = await asyncio.to_thread(zip_temp_directory, temp_dir)
 
-    return FileResponse(zip_path, filename=zip_path.name)
+    tasks = background_tasks or BackgroundTasks()
+    tasks.add_task(_cleanup, zip_path, temp_dir)
+
+    return FileResponse(zip_path, filename=zip_path.name, background=tasks)
 
 
 @app.post("/download/playlist")
-async def download_from_playlist(link: str = Form(...)):
+async def download_from_playlist(
+    link: str = Form(...), background_tasks: BackgroundTasks | None = None
+):
     """Fetch playlist ``link`` and return downloaded zip."""
 
     tracks = await asyncio.to_thread(fetch_spotify_playlist, link)
@@ -58,7 +85,10 @@ async def download_from_playlist(link: str = Form(...)):
     await _download_tracks(tracks, temp_dir)
     zip_path = await asyncio.to_thread(zip_temp_directory, temp_dir)
 
-    return FileResponse(zip_path, filename=zip_path.name)
+    tasks = background_tasks or BackgroundTasks()
+    tasks.add_task(_cleanup, zip_path, temp_dir)
+
+    return FileResponse(zip_path, filename=zip_path.name, background=tasks)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- clean up temporary files after serving download
- log failed downloads to **not_downloaded.txt**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498f97d43c8328bdc8ad99223dbaae