### PR TITLE
Add basic FastAPI test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ User provides a playlist link (e.g., from Spotify):
    uvicorn backend.main:app --reload
    ```
 
+### Running Tests
+
+After installing the dependencies you can run the test suite with
+`pytest`:
+
+```bash
+pytest
+```
+
 ### Frontend (optional)
 
 * Next.js + Tailwind CSS (planned UI)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from fastapi import FastAPI, File, UploadFile, Form, HTTPException, BackgroundTasks
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException, BackgroundTasks, Depends
 from fastapi.responses import FileResponse
 
 from .downloader.youtube import download_youtube_track
@@ -47,7 +47,7 @@ async def _download_tracks(tracks: list[str], temp_dir: Path) -> None:
 
 @app.post("/download/text")
 async def download_from_text(
-    file: UploadFile = File(...), background_tasks: BackgroundTasks | None = None
+    background_tasks: BackgroundTasks, file: UploadFile = File(...)
 ):
     """Accept a .txt file of tracks, download them and return a zip."""
 
@@ -72,7 +72,7 @@ async def download_from_text(
 
 @app.post("/download/playlist")
 async def download_from_playlist(
-    link: str = Form(...), background_tasks: BackgroundTasks | None = None
+    background_tasks: BackgroundTasks, link: str = Form(...)
 ):
     """Fetch playlist ``link`` and return downloaded zip."""
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, World"}


### PR DESCRIPTION
## Summary
- add initial pytest-based test for app startup
- adjust FastAPI endpoints for Python 3.12 compatibility
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849907fee148328ae26cd1972af78dd