### PR TITLE
Add Celery task system

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,0 +1,60 @@
+import os
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+from celery import Celery
+
+from .downloader.youtube import download_youtube_track
+from .utils.zipper import zip_temp_directory
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+
+celery = Celery(
+    "tasks",
+    broker=CELERY_BROKER_URL,
+    backend=CELERY_RESULT_BACKEND,
+)
+celery.conf.task_always_eager = os.getenv("CELERY_TASK_ALWAYS_EAGER", "false").lower() == "true"
+
+FAIL_LOG = Path("not_downloaded.txt")
+
+
+def _record_failure(track: str) -> None:
+    """Append ``track`` to the failure log."""
+    with FAIL_LOG.open("a") as f:
+        f.write(track + "\n")
+
+
+def _cleanup(zip_path: Path, temp_dir: Path) -> None:
+    """Delete created files and directories."""
+    if zip_path.exists():
+        zip_path.unlink()
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+async def _download_tracks_async(tracks: list[str], temp_dir: Path) -> None:
+    """Download all ``tracks`` into ``temp_dir`` concurrently."""
+
+    async def _download(track: str) -> None:
+        query = f"ytsearch1:{track}"
+        try:
+            await asyncio.to_thread(download_youtube_track, query, temp_dir)
+        except Exception:
+            await asyncio.to_thread(_record_failure, track)
+
+    tasks = [asyncio.create_task(_download(t)) for t in tracks]
+    await asyncio.gather(*tasks)
+
+
+@celery.task(bind=True)
+def download_tracks(self, tracks: list[str]) -> str:
+    """Celery task that downloads ``tracks`` and cleans up."""
+    temp_dir = Path(tempfile.mkdtemp(dir="temp"))
+    asyncio.run(_download_tracks_async(tracks, temp_dir))
+    zip_path = zip_temp_directory(temp_dir)
+    _cleanup(zip_path, temp_dir)
+    return str(zip_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ python-jose[cryptography]
 passlib[bcrypt]
 httpx<0.25
 python-multipart
+celery
+redis

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,6 +4,9 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+os.environ["CELERY_BROKER_URL"] = "memory://"
+os.environ["CELERY_RESULT_BACKEND"] = "cache+memory://"
+os.environ["CELERY_TASK_ALWAYS_EAGER"] = "false"
 from backend.main import app
 
 client = TestClient(app)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,9 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+os.environ["CELERY_BROKER_URL"] = "memory://"
+os.environ["CELERY_RESULT_BACKEND"] = "cache+memory://"
+os.environ["CELERY_TASK_ALWAYS_EAGER"] = "false"
 from backend.main import app
 
 client = TestClient(app)
@@ -13,3 +16,15 @@ def test_root_endpoint():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello, World"}
+
+
+def test_download_task_creation():
+    data = {"email": "task@example.com", "password": "secret"}
+    resp = client.post("/auth/register", json=data)
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    files = {"file": ("tracks.txt", b"song1")}
+    resp = client.post("/download/text", files=files, headers=headers)
+    assert resp.status_code == 200
+    assert "task_id" in resp.json()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3,6 +3,9 @@ import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+os.environ["CELERY_BROKER_URL"] = "memory://"
+os.environ["CELERY_RESULT_BACKEND"] = "cache+memory://"
+os.environ["CELERY_TASK_ALWAYS_EAGER"] = "false"
 from backend.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- configure Celery with Redis via new `backend/tasks.py`
- shift download endpoints to enqueue Celery jobs and expose task status/cancellation
- add redis and celery deps
- adjust tests to use Celery in memory and verify task creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499c2cee548328a43df96ee339f2fe