### PR TITLE
Organize downloads per user

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,7 +43,10 @@ async def download_from_text(
     if not lines:
         raise HTTPException(status_code=400, detail="File is empty")
 
-    task = download_tracks.delay(lines)
+    user_dir = Path("temp") / str(current_user.id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+
+    task = download_tracks.delay(lines, current_user.id)
     return {"task_id": task.id}
 
 
@@ -58,7 +61,10 @@ async def download_from_playlist(
     if not tracks:
         raise HTTPException(status_code=404, detail="No tracks found")
 
-    task = download_tracks.delay(tracks)
+    user_dir = Path("temp") / str(current_user.id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+
+    task = download_tracks.delay(tracks, current_user.id)
     return {"task_id": task.id}
 
 


### PR DESCRIPTION
## Summary
- store downloads under `temp/{user_id}` in the API endpoints
- cleanup user folders after zipping
- pass `user_id` through Celery tasks

## Testing
- `black backend/main.py backend/tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499dec3d9c832883f3458353465621