### PR TITLE
Add billing module with Stripe plans

### DIFF
--- a/backend/auth/models.py
+++ b/backend/auth/models.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime
 
 from .database import Base
 
@@ -10,6 +12,8 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     subscription = Column(String, default="free")
+    usage = Column(Integer, default=0)
+    quota_reset = Column(DateTime, default=datetime.utcnow)
     spotify_token = Column(String, nullable=True)
     youtube_token = Column(String, nullable=True)
     soundcloud_token = Column(String, nullable=True)

--- a/backend/billing.py
+++ b/backend/billing.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timedelta
+import os
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import stripe
+
+from .auth.router import get_current_user
+from .auth import models
+from .auth.database import get_db
+
+stripe.api_key = os.getenv("STRIPE_API_KEY", "")
+
+PLANS = {
+    "free": {"limit": 10, "period": "day", "price_id": "price_free"},
+    "starter": {"limit": 200, "period": "month", "price_id": "price_starter"},
+    "pro": {"limit": 1000, "period": "month", "price_id": "price_pro"},
+}
+
+router = APIRouter(prefix="/billing")
+
+
+def _should_reset(user: models.User, period: str) -> bool:
+    if user.quota_reset is None:
+        return True
+    now = datetime.utcnow()
+    if period == "day":
+        return now - user.quota_reset >= timedelta(days=1)
+    return now - user.quota_reset >= timedelta(days=30)
+
+
+def check_quota(user: models.User, db: Session, amount: int = 1) -> None:
+    plan = PLANS.get(user.subscription, PLANS["free"])
+    if _should_reset(user, plan["period"]):
+        user.usage = 0
+        user.quota_reset = datetime.utcnow()
+    if user.usage + amount > plan["limit"]:
+        raise HTTPException(status_code=402, detail="Quota exceeded")
+    user.usage += amount
+    db.add(user)
+    db.commit()
+
+
+def create_checkout_session(plan: str, user: models.User) -> str:
+    price_id = PLANS[plan]["price_id"]
+    session = stripe.checkout.Session.create(
+        mode="subscription",
+        payment_method_types=["card"],
+        line_items=[{"price": price_id, "quantity": 1}],
+        customer_email=user.email,
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    )
+    return session.url
+
+
+@router.get("/plans")
+def list_plans():
+    return PLANS
+
+
+@router.post("/upgrade")
+def upgrade_plan(
+    plan: str,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if plan not in PLANS:
+        raise HTTPException(status_code=400, detail="Invalid plan")
+    try:
+        url = create_checkout_session(plan, current_user)
+    except Exception as exc:  # pragma: no cover - network call
+        raise HTTPException(status_code=400, detail=str(exc))
+    current_user.subscription = plan
+    current_user.usage = 0
+    current_user.quota_reset = datetime.utcnow()
+    db.add(current_user)
+    db.commit()
+    return {"checkout_url": url}

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,11 +13,13 @@ from fastapi import (
     BackgroundTasks,
 )
 from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
 
 from .auth.router import router as auth_router, get_current_user
 from .auth import models as auth_models
-from .auth.database import engine
+from .auth.database import engine, get_db
 from .oauth import router as oauth_router
+from .billing import router as billing_router, check_quota
 
 from .downloader.spotify import fetch_spotify_playlist
 from .tasks import celery, download_tracks
@@ -29,12 +31,14 @@ app = FastAPI()
 auth_models.Base.metadata.create_all(bind=engine)
 app.include_router(auth_router)
 app.include_router(oauth_router)
+app.include_router(billing_router)
 
 
 @app.post("/download/text")
 async def download_from_text(
     file: UploadFile = File(...),
     current_user: auth_models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """Accept a .txt file of tracks and start async download."""
 
@@ -46,9 +50,9 @@ async def download_from_text(
     if not lines:
         raise HTTPException(status_code=400, detail="File is empty")
 
+    check_quota(current_user, db, amount=len(lines))
     user_dir = Path("temp") / str(current_user.id)
     user_dir.mkdir(parents=True, exist_ok=True)
-
     task = download_tracks.delay(lines, current_user.id)
     return {"task_id": task.id}
 
@@ -57,6 +61,7 @@ async def download_from_text(
 async def download_from_playlist(
     link: str = Form(...),
     current_user: auth_models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """Fetch playlist ``link`` and start async download."""
 
@@ -64,9 +69,9 @@ async def download_from_playlist(
     if not tracks:
         raise HTTPException(status_code=404, detail="No tracks found")
 
+    check_quota(current_user, db, amount=len(tracks))
     user_dir = Path("temp") / str(current_user.id)
     user_dir.mkdir(parents=True, exist_ok=True)
-
     task = download_tracks.delay(tracks, current_user.id)
     return {"task_id": task.id}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ httpx<0.25
 python-multipart
 celery
 redis
+stripe

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["CELERY_BROKER_URL"] = "memory://"
+os.environ["CELERY_RESULT_BACKEND"] = "cache+memory://"
+os.environ["CELERY_TASK_ALWAYS_EAGER"] = "false"
+os.environ["STRIPE_API_KEY"] = "sk_test"
+
+from backend.main import app
+import backend.billing as billing
+
+client = TestClient(app)
+
+
+def _register(email="bill@example.com"):
+    data = {"email": email, "password": "secret"}
+    resp = client.post("/auth/register", json=data)
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_list_plans():
+    resp = client.get("/billing/plans")
+    assert resp.status_code == 200
+    assert "free" in resp.json()
+
+
+def test_quota_enforcement(monkeypatch):
+    token = _register("bill1@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    monkeypatch.setattr(billing, "create_checkout_session", lambda plan, user: "url")
+
+    for _ in range(10):
+        files = {"file": ("tracks.txt", b"song")}
+        resp = client.post("/download/text", files=files, headers=headers)
+        assert resp.status_code == 200
+
+    files = {"file": ("tracks.txt", b"song")}
+    resp = client.post("/download/text", files=files, headers=headers)
+    assert resp.status_code == 402
+
+
+def test_upgrade_plan(monkeypatch):
+    token = _register("bill2@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    monkeypatch.setattr(billing, "create_checkout_session", lambda plan, user: "checkout")
+    resp = client.post("/billing/upgrade", headers=headers, params={"plan": "pro"})
+    assert resp.status_code == 200
+    assert resp.json()["checkout_url"] == "checkout"


### PR DESCRIPTION
## Summary
- create `billing.py` with Stripe integration and plan management
- track user quota usage in `User` model
- enforce plan quotas in download endpoints
- expose `/billing/plans` and `/billing/upgrade`
- include basic billing tests
- add Stripe to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a59618ec8328a3808cb8e1310cce