### PR TITLE
Make JWT secret configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Celery worker:
 ```bash
 celery -A backend.tasks worker --loglevel=info
 ```
+Set `JWT_SECRET` in your environment to configure the token signing key.
 
 
 ---

--- a/backend/auth/jwt_utils.py
+++ b/backend/auth/jwt_utils.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
+import os
 from jose import jwt
 
-SECRET_KEY = "change_this_secret"  # In production use env variable
+SECRET_KEY = os.getenv("JWT_SECRET", "change_this_secret")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 


### PR DESCRIPTION
## Summary
- make JWT SECRET_KEY load from `JWT_SECRET` env var
- document `JWT_SECRET` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f1191fe08328a1613159199d8c17