### PR TITLE
Centralize frontend API base URL

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,1 @@
+export const API = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";

--- a/frontend/src/app/connect/page.tsx
+++ b/frontend/src/app/connect/page.tsx
@@ -2,6 +2,7 @@
 import { useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 export default function Connect() {
   const { token, loaded } = useContext(AuthContext)
@@ -13,7 +14,7 @@ export default function Connect() {
   }
 
   const connect = async (service: string) => {
-    const resp = await fetch(`http://localhost:8000/connect/${service}`, {
+    const resp = await fetch(`${API}/connect/${service}`, {
       headers: { Authorization: `Bearer ${token}` },
       redirect: 'manual'
     })

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 export default function Dashboard() {
   const { token, loaded } = useContext(AuthContext)
@@ -23,7 +24,7 @@ export default function Dashboard() {
     if (!tasks.length) return
     const timer = setInterval(() => {
       tasks.forEach(async id => {
-        const resp = await fetch(`http://localhost:8000/status/${id}`)
+        const resp = await fetch(`${API}/status/${id}`)
         if (resp.ok) {
           const data = await resp.json()
           setStatuses(s => ({ ...s, [id]: data.status }))
@@ -35,7 +36,7 @@ export default function Dashboard() {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const resp = await fetch('http://localhost:8000/download/playlist', {
+    const resp = await fetch(`${API}/download/playlist`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: new URLSearchParams({ link })

--- a/frontend/src/app/downloads/[taskId]/page.tsx
+++ b/frontend/src/app/downloads/[taskId]/page.tsx
@@ -2,6 +2,7 @@
 import { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../../AuthContext'
+import { API } from '@/api'
 
 interface Info {
   status: string
@@ -19,13 +20,13 @@ export default function DownloadSummary({ params }: { params: { taskId: string }
       router.push('/login')
       return
     }
-    fetch(`http://localhost:8000/status/${taskId}`)
+    fetch(`${API}/status/${taskId}`)
       .then(r => r.ok && r.json())
       .then(data => data && setInfo(data))
   }, [loaded, token, taskId])
 
   const download = async () => {
-    const resp = await fetch(`http://localhost:8000/download/file/${taskId}`, {
+    const resp = await fetch(`${API}/download/file/${taskId}`, {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (resp.ok) {
@@ -44,7 +45,7 @@ export default function DownloadSummary({ params }: { params: { taskId: string }
     const form = new FormData()
     const file = new Blob([info.failed.join('\n')], { type: 'text/plain' })
     form.append('file', file, 'tracks.txt')
-    const resp = await fetch('http://localhost:8000/download/text', {
+    const resp = await fetch(`${API}/download/text`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: form

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 export default function Login() {
   const [email, setEmail] = useState('')
@@ -11,7 +12,7 @@ export default function Login() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const resp = await fetch('http://localhost:8000/auth/login', {
+    const resp = await fetch(`${API}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })

--- a/frontend/src/app/plans/page.tsx
+++ b/frontend/src/app/plans/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 interface Plan {
   limit: number
@@ -18,13 +19,13 @@ export default function Plans() {
       router.push('/login')
       return
     }
-    fetch('http://localhost:8000/billing/plans')
+    fetch(`${API}/billing/plans`)
       .then(r => r.json())
       .then(setPlans)
   }, [loaded, token])
 
   const upgrade = async (plan: string) => {
-    const resp = await fetch(`http://localhost:8000/billing/upgrade?plan=${plan}`, {
+    const resp = await fetch(`${API}/billing/upgrade?plan=${plan}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` }
     })

--- a/frontend/src/app/progress/[taskId]/page.tsx
+++ b/frontend/src/app/progress/[taskId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState, useContext } from 'react'
 import { AuthContext } from '../../AuthContext'
+import { API } from '@/api'
 import { useRouter } from 'next/navigation'
 
 export default function Progress({ params }: { params: { taskId: string } }) {
@@ -11,7 +12,7 @@ export default function Progress({ params }: { params: { taskId: string } }) {
 
   useEffect(() => {
     const timer = setInterval(async () => {
-      const resp = await fetch(`http://localhost:8000/status/${taskId}`)
+      const resp = await fetch(`${API}/status/${taskId}`)
       if (resp.ok) {
         const data = await resp.json()
         setStatus(data.status)
@@ -24,7 +25,7 @@ export default function Progress({ params }: { params: { taskId: string } }) {
   }, [taskId])
 
   const download = async () => {
-    const resp = await fetch(`http://localhost:8000/download/file/${taskId}`, {
+    const resp = await fetch(`${API}/download/file/${taskId}`, {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (resp.ok) {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 export default function Register() {
   const [email, setEmail] = useState('')
@@ -11,7 +12,7 @@ export default function Register() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const resp = await fetch('http://localhost:8000/auth/register', {
+    const resp = await fetch(`${API}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import { AuthContext } from '../AuthContext'
+import { API } from '@/api'
 
 export default function Upload() {
   const [link, setLink] = useState('')
@@ -10,7 +11,7 @@ export default function Upload() {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const resp = await fetch('http://localhost:8000/download/playlist', {
+    const resp = await fetch(`${API}/download/playlist`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`


### PR DESCRIPTION
## Summary
- add `frontend/src/api.ts` to share the API base URL
- update pages to import and use this constant for fetch calls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684bec80b80c83288a250a90a6d4e062