### PR TITLE
Read OAuth config from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ celery -A backend.tasks worker --loglevel=info
 ```
 Set `JWT_SECRET` in your environment to configure the token signing key.
 
+Set `SPOTIFY_CLIENT_ID` and `SPOTIFY_REDIRECT_URI` for Spotify OAuth.
+Set `YOUTUBE_CLIENT_ID` and `YOUTUBE_REDIRECT_URI` for YouTube OAuth.
+Set `SOUNDCLOUD_CLIENT_ID` and `SOUNDCLOUD_REDIRECT_URI` for SoundCloud OAuth.
+
 
 ---
 

--- a/backend/oauth/soundcloud.py
+++ b/backend/oauth/soundcloud.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
+import os
 
 from ..auth.router import get_current_user
 from ..auth import models
@@ -7,7 +8,15 @@ from ..auth.database import get_db
 
 router = APIRouter()
 
-AUTH_URL = "https://soundcloud.com/connect?client_id=dummy&response_type=code&redirect_uri=http://localhost/callback/soundcloud"
+CLIENT_ID = os.getenv("SOUNDCLOUD_CLIENT_ID", "dummy")
+REDIRECT_URI = os.getenv(
+    "SOUNDCLOUD_REDIRECT_URI",
+    "http://localhost/callback/soundcloud",
+)
+AUTH_URL = (
+    "https://soundcloud.com/connect?client_id="
+    f"{CLIENT_ID}&response_type=code&redirect_uri={REDIRECT_URI}"
+)
 
 @router.get("/connect/soundcloud")
 def connect_soundcloud(current_user: models.User = Depends(get_current_user)):

--- a/backend/oauth/spotify.py
+++ b/backend/oauth/spotify.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
+import os
 
 from ..auth.router import get_current_user
 from ..auth import models
@@ -7,7 +8,12 @@ from ..auth.database import get_db
 
 router = APIRouter()
 
-AUTH_URL = "https://accounts.spotify.com/authorize?client_id=dummy&response_type=code&redirect_uri=http://localhost/callback/spotify"
+CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID", "dummy")
+REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI", "http://localhost/callback/spotify")
+AUTH_URL = (
+    "https://accounts.spotify.com/authorize?client_id="
+    f"{CLIENT_ID}&response_type=code&redirect_uri={REDIRECT_URI}"
+)
 
 @router.get("/connect/spotify")
 def connect_spotify(current_user: models.User = Depends(get_current_user)):

--- a/backend/oauth/youtube.py
+++ b/backend/oauth/youtube.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
+import os
 
 from ..auth.router import get_current_user
 from ..auth import models
@@ -7,7 +8,12 @@ from ..auth.database import get_db
 
 router = APIRouter()
 
-AUTH_URL = "https://accounts.google.com/o/oauth2/auth?client_id=dummy&response_type=code&redirect_uri=http://localhost/callback/youtube"
+CLIENT_ID = os.getenv("YOUTUBE_CLIENT_ID", "dummy")
+REDIRECT_URI = os.getenv("YOUTUBE_REDIRECT_URI", "http://localhost/callback/youtube")
+AUTH_URL = (
+    "https://accounts.google.com/o/oauth2/auth?client_id="
+    f"{CLIENT_ID}&response_type=code&redirect_uri={REDIRECT_URI}"
+)
 
 @router.get("/connect/youtube")
 def connect_youtube(current_user: models.User = Depends(get_current_user)):


### PR DESCRIPTION
## Summary
- load OAuth client IDs and redirect URIs from environment variables
- document `SPOTIFY_CLIENT_ID`, `YOUTUBE_CLIENT_ID`, and `SOUNDCLOUD_CLIENT_ID`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be921ad588328b102ac96e6d31b28