### PR TITLE
Fix SQLAlchemy deprecation warning

### DIFF
--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -60,7 +60,7 @@ def get_current_user(
     except JWTError:
         raise credentials_exception
 
-    user = db.query(models.User).get(int(user_id))
+    user = db.get(models.User, int(user_id))
     if user is None:
         raise credentials_exception
     return user


### PR DESCRIPTION
## Summary
- stop using deprecated `Query.get()` method
- use new `Session.get()` in auth router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf35baf008328ad98fd93351a6d26